### PR TITLE
Fix Either/FilterValue compiler error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ sudo: false
 
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.8.4
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
@@ -24,12 +22,12 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - cabal install --only-dependencies --enable-tests --enable-benchmarks
+ - cabal install --only-dependencies --enable-benchmarks
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2 --disable-shared # -v2 provides useful information for debugging
+ - cabal configure --enable-benchmarks -v2 --disable-shared # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
  - cabal check

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - cabal install --only-dependencies --enable-benchmarks
+ - cabal install --only-dependencies
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-benchmarks -v2 --disable-shared # -v2 provides useful information for debugging
+ - cabal configure -v2 --disable-shared # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
  - cabal check

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,3 @@
+## 0.2.4
+
+Fixes compatibility with persistent-2.10.0 and above [#1](https://github.com/greydot/persistent-iproute/pull/1)

--- a/Database/Persist/IP.hs
+++ b/Database/Persist/IP.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | This module adds support for some of PostgreSQL operators on IP addresses
 --   and networks. See <http://www.postgresql.org/docs/9.4/static/functions-net.html>
@@ -17,26 +18,34 @@ import Database.Persist
 import Database.Persist.Instances.IP ()
 import Unsafe.Coerce (unsafeCoerce)
 
+#if MIN_VERSION_persistent(2,10,0) 
+#define VALUE_CONSTRUCTOR FilterValue 
+#else 
+#define VALUE_CONSTRUCTOR Left 
+#endif
+
 -- | The record range is contained within the specified range. Corresponds to PgSQL operator <<.
 (<:<.) :: EntityField record IPRange -> IPRange -> Filter record
-field <:<. range = Filter field (FilterValue range) (BackendSpecificFilter "<<")
+field <:<. range = Filter field (VALUE_CONSTRUCTOR range) (BackendSpecificFilter "<<")
 
 -- | The record range contains the specified range. Corresponds to PgSQL operator >>.
 (>:>.) :: EntityField record IPRange -> IPRange -> Filter record
-field >:>. range = Filter field (FilterValue range) (BackendSpecificFilter ">>")
+field >:>. range = Filter field (VALUE_CONSTRUCTOR range) (BackendSpecificFilter ">>")
 
 -- | The record range is contained within or equals to the specified range. Corresponds to PgSQL operator <<=.
 (<:<=) :: EntityField record IPRange -> IPRange -> Filter record
-field <:<= range = Filter field (FilterValue range) (BackendSpecificFilter "<<=")
+field <:<= range = Filter field (VALUE_CONSTRUCTOR range) (BackendSpecificFilter "<<=")
 
 -- | The record range contains or equals to the specified range. Corresponds to PgSQL operator >>=.
 (>:>=) :: EntityField record IPRange -> IPRange -> Filter record
-field >:>= range = Filter field (FilterValue range) (BackendSpecificFilter ">>=")
+field >:>= range = Filter field (VALUE_CONSTRUCTOR range) (BackendSpecificFilter ">>=")
 
 -- | The record address is contained within the specified range. Corresponds to PgSQL operator <<.
 (<.<.) :: EntityField record IP -> IPRange -> Filter record
-field <.<. range = Filter (unsafeCoerce field :: EntityField record IPRange) (FilterValue range) (BackendSpecificFilter "<<")
+field <.<. range = Filter (unsafeCoerce field :: EntityField record IPRange) (VALUE_CONSTRUCTOR range) (BackendSpecificFilter "<<")
 
 -- | The record range contains the specified address. Corresponds to PgSQL operator >>.
 (>.>.) :: EntityField record IPRange -> IP -> Filter record
-field >.>. ip = Filter (unsafeCoerce field :: EntityField record IP) (FilterValue ip) (BackendSpecificFilter ">>")
+field >.>. ip = Filter (unsafeCoerce field :: EntityField record IP) (VALUE_CONSTRUCTOR ip) (BackendSpecificFilter ">>")
+
+#undef VALUE_CONSTRUCTOR

--- a/Database/Persist/IP.hs
+++ b/Database/Persist/IP.hs
@@ -19,24 +19,24 @@ import Unsafe.Coerce (unsafeCoerce)
 
 -- | The record range is contained within the specified range. Corresponds to PgSQL operator <<.
 (<:<.) :: EntityField record IPRange -> IPRange -> Filter record
-field <:<. range = Filter field (Left range) (BackendSpecificFilter "<<")
+field <:<. range = Filter field (FilterValue range) (BackendSpecificFilter "<<")
 
 -- | The record range contains the specified range. Corresponds to PgSQL operator >>.
 (>:>.) :: EntityField record IPRange -> IPRange -> Filter record
-field >:>. range = Filter field (Left range) (BackendSpecificFilter ">>")
+field >:>. range = Filter field (FilterValue range) (BackendSpecificFilter ">>")
 
 -- | The record range is contained within or equals to the specified range. Corresponds to PgSQL operator <<=.
 (<:<=) :: EntityField record IPRange -> IPRange -> Filter record
-field <:<= range = Filter field (Left range) (BackendSpecificFilter "<<=")
+field <:<= range = Filter field (FilterValue range) (BackendSpecificFilter "<<=")
 
 -- | The record range contains or equals to the specified range. Corresponds to PgSQL operator >>=.
 (>:>=) :: EntityField record IPRange -> IPRange -> Filter record
-field >:>= range = Filter field (Left range) (BackendSpecificFilter ">>=")
+field >:>= range = Filter field (FilterValue range) (BackendSpecificFilter ">>=")
 
 -- | The record address is contained within the specified range. Corresponds to PgSQL operator <<.
 (<.<.) :: EntityField record IP -> IPRange -> Filter record
-field <.<. range = Filter (unsafeCoerce field :: EntityField record IPRange) (Left range) (BackendSpecificFilter "<<")
+field <.<. range = Filter (unsafeCoerce field :: EntityField record IPRange) (FilterValue range) (BackendSpecificFilter "<<")
 
 -- | The record range contains the specified address. Corresponds to PgSQL operator >>.
 (>.>.) :: EntityField record IPRange -> IP -> Filter record
-field >.>. ip = Filter (unsafeCoerce field :: EntityField record IP) (Left ip) (BackendSpecificFilter ">>")
+field >.>. ip = Filter (unsafeCoerce field :: EntityField record IP) (FilterValue ip) (BackendSpecificFilter ">>")

--- a/persistent-iproute.cabal
+++ b/persistent-iproute.cabal
@@ -26,7 +26,7 @@ library
                        iproute >= 1.5,
                        http-api-data,
                        path-pieces,
-                       persistent >= 2.10.0,
+                       persistent,
                        text
   default-language:    Haskell2010
   ghc-options:       -Wall -fno-warn-orphans

--- a/persistent-iproute.cabal
+++ b/persistent-iproute.cabal
@@ -1,5 +1,5 @@
 name:                persistent-iproute
-version:             0.2.3
+version:             0.2.4
 synopsis:            Persistent instances for types in iproute
 description:         Persistent instances and operators for types in iproute to use with PostgreSQL.
 license:             BSD3

--- a/persistent-iproute.cabal
+++ b/persistent-iproute.cabal
@@ -26,7 +26,7 @@ library
                        iproute >= 1.5,
                        http-api-data,
                        path-pieces,
-                       persistent,
+                       persistent >= 2.10.0,
                        text
   default-language:    Haskell2010
   ghc-options:       -Wall -fno-warn-orphans


### PR DESCRIPTION
It looks like in old versions of persistent (e.g. https://hackage.haskell.org/package/persistent-2.9.2/docs/Database-Persist-Types.html), Filter had these constructors:

```
data Filter record = forall typ. PersistField typ => Filter
    { filterField  :: EntityField record typ
    , filterValue  :: Either typ [typ] -- FIXME
    , filterFilter :: PersistFilter -- FIXME
    }
    | FilterAnd [Filter record] -- ^ convenient for internal use, not needed for the API
    | FilterOr  [Filter record]
    | BackendFilter
          (BackendSpecificFilter (PersistEntityBackend record) record)
```

but in newer versions, it changed (https://hackage.haskell.org/package/persistent-2.10.4/docs/Database-Persist-Types.html#t:Filter):

```
data Filter record = forall typ. PersistField typ => Filter
    { filterField  :: EntityField record typ
    , filterValue  :: FilterValue typ
    , filterFilter :: PersistFilter -- FIXME
    }
    | FilterAnd [Filter record] -- ^ convenient for internal use, not needed for the API
    | FilterOr  [Filter record]
    | BackendFilter
          (BackendSpecificFilter (PersistEntityBackend record) record)
```

resulting in this compiler error:

```
/Users/maximiliantagher/Documents/Clones/Haskell/persistent-iproute/Database/Persist/IP.hs:42:71: error:
    • Couldn't match expected type ‘FilterValue IP’
                  with actual type ‘Either IP b0’
    • In the second argument of ‘Filter’, namely ‘(Left ip)’
      In the expression:
        Filter
          (unsafeCoerce field :: EntityField record IP)
          (Left ip)
          (BackendSpecificFilter ">>")
      In an equation for ‘>.>.’:
          field >.>. ip
            = Filter
                (unsafeCoerce field :: EntityField record IP)
                (Left ip)
                (BackendSpecificFilter ">>")
   |
42 | field >.>. ip = Filter (unsafeCoerce field :: EntityField record IP) (Left ip) (BackendSpecificFilter ">>")
   |                                                                       ^^^^^^^
```

`FilterValue` is defined like this:

```
data FilterValue typ where
  FilterValue  :: typ -> FilterValue typ
  FilterValues :: [typ] -> FilterValue typ
  UnsafeValue  :: forall a typ. PersistField a => a -> FilterValue typ
```

So, my reading of the situation is that it needed a third constructor, so what was previously `Left`/`Right` is now `FilterValue`/`FilterValues`, and just a switchout is necessary. I compiled with:

```
extra-deps: [persistent-2.10.4]
```

to confirm this fixes the compilation error.

I haven't tested this at runtime though.